### PR TITLE
Changes to help colcon

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,12 +49,12 @@ endif()
 
 find_package(Boost 1.72 REQUIRED)
 find_package(Eigen3 REQUIRED)
+add_definitions(/DROOT_DIR="${CMAKE_CURRENT_LIST_DIR}")
 if(ENABLE_TESTING)
   enable_testing()
   message(
     "Building Tests."
   )
-  add_definitions(/DROOT_DIR="${CMAKE_CURRENT_LIST_DIR}")
   add_subdirectory(test)
 endif()
 

--- a/lib/modeling/Lloyd2003Muscle.cpp
+++ b/lib/modeling/Lloyd2003Muscle.cpp
@@ -288,7 +288,7 @@ DoubleT Lloyd2003Muscle::calculateTendonStiffness() const {
     return tendonStiffness;
 }
 
-auto Lloyd2003Muscle::calculateJacobian() const {
+Eigen::Matrix<DoubleT, 1, 10> Lloyd2003Muscle::calculateJacobian() const {
     constexpr int N = 1;
     using boost::math::differentiation::make_ftuple;
     const auto variables =

--- a/lib/modeling/ceinms2/Lloyd2003Muscle.h
+++ b/lib/modeling/ceinms2/Lloyd2003Muscle.h
@@ -188,7 +188,7 @@ class Lloyd2003Muscle {
     [[nodiscard]] DoubleT calculateTendonStrain() const;
     [[nodiscard]] DoubleT calculateTendonLength() const;
     [[nodiscard]] DoubleT calculateTendonForce() const;
-    [[nodiscard]] auto calculateJacobian() const;
+    [[nodiscard]] Eigen::Matrix<DoubleT, 1, 10> calculateJacobian() const;
   private:
 
      template<typename I0,


### PR DESCRIPTION
Changes are only minor and do not change ceinms2 operations.

As a reminder:
The compiler can find the correct type for auto when building ceinm2 alone, but cannot when building using colcon in the BioSpine workspace. If we want a better understanding we could test building in a more isolated colcon environments, eg. remove all other components in the control pkg.