### PR TITLE
Moved CMake messages from stderr to stdout

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,9 +3,7 @@ cmake_minimum_required(VERSION 3.15)
 if(DEFINED ENV{VCPKG_ROOT} AND NOT DEFINED CMAKE_TOOLCHAIN_FILE)
   set(CMAKE_TOOLCHAIN_FILE "$ENV{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake"
       CACHE STRING "")
-  message(
-    "Using vcpkg."
-  )
+  message( STATUS "Using vcpkg." )
 endif()
 
 # Set the project name to your project name, my project isn't very descriptive
@@ -52,9 +50,7 @@ find_package(Eigen3 REQUIRED)
 add_definitions(/DROOT_DIR="${CMAKE_CURRENT_LIST_DIR}")
 if(ENABLE_TESTING)
   enable_testing()
-  message(
-    "Building Tests."
-  )
+  message( STATUS "Building Tests." )
   add_subdirectory(test)
 endif()
 

--- a/cmake/StandardProjectSettings.cmake
+++ b/cmake/StandardProjectSettings.cmake
@@ -12,10 +12,10 @@ endif()
 
 find_program(CCACHE ccache)
 if(CCACHE)
-  message("using ccache")
+  message( STATUS "using ccache")
   set(CMAKE_CXX_COMPILER_LAUNCHER ${CCACHE})
 else()
-  message("ccache not found cannot use")
+  message( STATUS "ccache not found cannot use")
 endif()
 
 # Generate compile_commands.json to make it easier to work with clang based


### PR DESCRIPTION
Undefined type of message is sent to stderr by default. Cleaner output helps when ceinms2 is a dependency of other projects.